### PR TITLE
fix while creating the non-root-user 

### DIFF
--- a/non-root-user.yml
+++ b/non-root-user.yml
@@ -4,7 +4,7 @@
     - name: creating 'ubuntu' user
       user: name=ubuntu append=yes state=present createhome=yes shell=/bin/bash
 
-    - name: 'ubuntu' for passwordless sudo
+    - name: creating 'ubuntu' for passwordless sudo
       lineinfile:
         dest: /etc/sudoers
         line: 'ubuntu ALL=(ALL) NOPASSWD: ALL'


### PR DESCRIPTION
The issue is with the configuration while creation of non root user. 
File name :  
non-root-user.yml 
changes : 
In Line no 7 : 
Current  : 
- name: 'ubuntu' for passwordless sudo 
Changed: 
- name: creating 'ubuntu' for passwordless sudo 
